### PR TITLE
pin urllib version to fix incompatibility with python3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ prometheus-client==0.20.0
 python-telegram-bot==13.15
 requests==2.31.0
 telegram-click==5.0.1
+urllib3==1.26.15


### PR DESCRIPTION
Running the docker container restults in the following error:
```
/usr/local/lib/python3.12/site-packages/telegram/utils/request.py:54: UserWarning: python-telegram-bot wasn't properly installed. Please refer to README.rst on how to properly install.
  warnings.warn(
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/telegram/utils/request.py", line 36, in <module>
    import telegram.vendor.ptb_urllib3.urllib3 as urllib3
  File "/usr/local/lib/python3.12/site-packages/telegram/vendor/ptb_urllib3/urllib3/__init__.py", line 7, in <module>
    from .connectionpool import (
  File "/usr/local/lib/python3.12/site-packages/telegram/vendor/ptb_urllib3/urllib3/connectionpool.py", line 11, in <module>
    from .exceptions import (
  File "/usr/local/lib/python3.12/site-packages/telegram/vendor/ptb_urllib3/urllib3/exceptions.py", line 2, in <module>
    from .packages.six.moves.http_client import (
ModuleNotFoundError: No module named 'telegram.vendor.ptb_urllib3.urllib3.packages.six.moves'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/frundenbot", line 5, in <module>
    from frundenbot.main import cli
  File "/usr/local/lib/python3.12/site-packages/frundenbot/main.py", line 29, in <module>
    from telegram import (InlineQueryResultArticle, InputTextMessageContent,
  File "/usr/local/lib/python3.12/site-packages/telegram/__init__.py", line 187, in <module>
    from .bot import Bot
  File "/usr/local/lib/python3.12/site-packages/telegram/bot.py", line 107, in <module>
    from telegram.utils.request import Request
  File "/usr/local/lib/python3.12/site-packages/telegram/utils/request.py", line 44, in <module>
    import urllib3.contrib.appengine as appengine  # type: ignore[no-redef]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'urllib3.contrib.appengine'
```
This can be fixed by pining the version of urlib that is installed, see [stackoverflow](https://stackoverflow.com/questions/78017690/python-telegram-bot-v13-11-incompatible-with-requests-and-urllib3-libraries-usin/78017691#78017691) for some further details.